### PR TITLE
👷 use latest major version for actions/checkout

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       # Required to access files of this repository
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Download Shellcheck and add it to the workflow path
       - name: Download Shellcheck


### PR DESCRIPTION
Use latest major version of [actions/checkout](https://github.com/actions/checkout) for GitHub Actions.